### PR TITLE
iOS8対応：blocksKitのhandlerに処理が回ってこないバグの修正

### DIFF
--- a/HALBirdRecord/Pods-acknowledgements.plist
+++ b/HALBirdRecord/Pods-acknowledgements.plist
@@ -38,25 +38,32 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 
 For Bolts software
 
-Copyright (c) 2013, Facebook, Inc.
-All rights reserved.
+Copyright (c) 2013-present, Facebook, Inc. All rights reserved.
 
-Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this list of conditions and the following
-  disclaimer.
-  
-* Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following
-  disclaimer in the documentation and/or other materials provided with the distribution.
-  
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
-INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
-THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-</string>
+ * Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+ * Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+ * Neither the name Facebook nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific
+   prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.</string>
 			<key>Title</key>
 			<string>Bolts</string>
 			<key>Type</key>

--- a/Podfile
+++ b/Podfile
@@ -2,7 +2,7 @@ platform :ios, '6.1'
 
 pod 'GoogleAnalytics-iOS-SDK', '~> 3.0'
 pod 'FMDB'
-pod 'BlocksKit'
+pod 'BlocksKit', '>= 2.2.5'
 pod 'SVProgressHUD'
 pod 'SZTextView', '~> 1.1.0'
 pod 'MSSimpleGauge', '~> 0.5'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -14,9 +14,14 @@ PODS:
   - BlocksKit/UIKit (2.2.2):
     - BlocksKit/Core
     - BlocksKit/DynamicDelegate
-  - Bolts (1.1.3)
+  - Bolts (1.1.5):
+    - Bolts/AppLinks
+    - Bolts/Tasks
+  - Bolts/AppLinks (1.1.5):
+    - Bolts/Tasks
+  - Bolts/Tasks (1.1.5)
   - CorePlot (1.5.1)
-  - Facebook-iOS-SDK (3.22.0):
+  - Facebook-iOS-SDK (3.23.2):
     - Bolts (~> 1.0)
   - FMDB (2.2):
     - FMDB/standard
@@ -51,17 +56,17 @@ DEPENDENCIES:
   - SZTextView (~> 1.1.0)
 
 SPEC CHECKSUMS:
-  BlocksKit: 49fda17cbd628f3d6683f62de57edeaa315b386c
-  Bolts: 3db0a875235e0c9042b013af13af0f00f79b102c
-  CorePlot: b15cb1a9a687b9576545104248d6e22033e678bb
-  Facebook-iOS-SDK: 0eda8ff7120aada0a9c5f98552f7625da6c3440a
-  FMDB: f6f4511ad1e9ace38e9b6f4d83c2cddaabf98ea6
-  GoogleAnalytics-iOS-SDK: 4577fb25381a71c5beac455b18ebb288fc4f44e9
-  Kiwi: c73667f2b84cbf36f1a3830267c5a4ae8dcbd8ba
-  LUKeychainAccess: 3559d5939dee13858809c2405164db901330d343
-  MSSimpleGauge: 2639e8ee6f9b998dddd03b54f4a7b5a23eb473f5
-  Parse: ffebaecaddd32cb52671010f81567c298ff93d04
-  SVProgressHUD: 5034c6e22b8c2ca3e09402e48d41ed0340aa1c50
-  SZTextView: 28d06dc4c19e1372a174ec48fba2324d6796b1d6
+  BlocksKit: 8557ca36d58151724e4027b81e429812ed7dc06c
+  Bolts: aac24961496d504aa56fc267cde95162a71bac39
+  CorePlot: 53d823a4de5e4e662311cae4cdcb230e146c5c90
+  Facebook-iOS-SDK: cd87f0b2f0c1d9574b44e8fa2baacc275524bac3
+  FMDB: 0678cab3b024ea6a2e6ea5dd91fc8eb9a296bf57
+  GoogleAnalytics-iOS-SDK: c0e1b70cd54e0061c3edf27ddf91948895de73cd
+  Kiwi: 5d574f31ceac18ba417f5dac6c7f9f1a3e86962d
+  LUKeychainAccess: b1a831628aa84ca531a71d9309f2cf8e5d194e56
+  MSSimpleGauge: e5f7bf2561f1338055fcd321c5469b0d6c689d14
+  Parse: edcb452d76e52009de584a410d77037fdb404651
+  SVProgressHUD: 46088807596a795cbcb4affd92cf3f13b6ab3dda
+  SZTextView: 9c0ae45316c4175c699451d12c6d4a8b682032a8
 
 COCOAPODS: 0.32.1

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,17 +1,21 @@
 PODS:
-  - BlocksKit (2.2.2):
+  - BlocksKit (2.2.5):
     - BlocksKit/All
-  - BlocksKit/All (2.2.2):
     - BlocksKit/Core
     - BlocksKit/DynamicDelegate
     - BlocksKit/MessageUI
     - BlocksKit/UIKit
-  - BlocksKit/Core (2.2.2)
-  - BlocksKit/DynamicDelegate (2.2.2)
-  - BlocksKit/MessageUI (2.2.2):
+  - BlocksKit/All (2.2.5):
     - BlocksKit/Core
     - BlocksKit/DynamicDelegate
-  - BlocksKit/UIKit (2.2.2):
+    - BlocksKit/MessageUI
+    - BlocksKit/UIKit
+  - BlocksKit/Core (2.2.5)
+  - BlocksKit/DynamicDelegate (2.2.5)
+  - BlocksKit/MessageUI (2.2.5):
+    - BlocksKit/Core
+    - BlocksKit/DynamicDelegate
+  - BlocksKit/UIKit (2.2.5):
     - BlocksKit/Core
     - BlocksKit/DynamicDelegate
   - Bolts (1.1.5):
@@ -44,7 +48,7 @@ PODS:
   - SZTextView (1.1.1)
 
 DEPENDENCIES:
-  - BlocksKit
+  - BlocksKit (>= 2.2.5)
   - CorePlot (~> 1.4)
   - FMDB
   - GoogleAnalytics-iOS-SDK (~> 3.0)
@@ -56,7 +60,7 @@ DEPENDENCIES:
   - SZTextView (~> 1.1.0)
 
 SPEC CHECKSUMS:
-  BlocksKit: 8557ca36d58151724e4027b81e429812ed7dc06c
+  BlocksKit: 7f422b971407001178d181a43b99014ea2591fe6
   Bolts: aac24961496d504aa56fc267cde95162a71bac39
   CorePlot: 53d823a4de5e4e662311cae4cdcb230e146c5c90
   Facebook-iOS-SDK: cd87f0b2f0c1d9574b44e8fa2baacc275524bac3


### PR DESCRIPTION
BlocksKitを2.2.5に上げることで修正